### PR TITLE
feat: add States container for multi-state management

### DIFF
--- a/.agent/skills/htag-development/SKILL.md
+++ b/.agent/skills/htag-development/SKILL.md
@@ -85,8 +85,13 @@ class Card(Tag.div):
 htag supports both traditional "dirty-marking" and modern reactive `State`.
 
 **Reactive State (Transparent Proxy)**:
-- Use `from htag import State`.
-- Declare state variables: `self.count = State(0)`.
+- Use `from htag import States` (preferred) or `from htag import State`.
+- **`States` Container (Recommended)**: Create multiple states effortlessly in one go using keyword arguments. The `States` object delegates attribute access to individual `State` instances. It supports bulk `.dump()` (to dictionary) and `.load(dict)`.
+  ```python
+  self.s = States(count=0, loading=False)
+  self.s.count += 1
+  ```
+- **Single `State`**: Declare state variables individually: `self.count = State(0)`.
 - **State Promotion**: The `State` constructor is idempotent. You can safely "promote" any input to a `State` using `s = State(value)`. If `value` is already a `State` (or a `_StateProxy`), it is returned as-is, preserving its identity and observers. This is the recommended way for component developers to handle potentially reactive arguments.
 - Use operators directly: `self.count += 1`, `if self.count > 0: ...` (full support for comparison and math).
 - Automatic notification on method calls: `self.items.append("new")`.

--- a/htag/__init__.py
+++ b/htag/__init__.py
@@ -1,4 +1,4 @@
-from .core import prevent, stop, State, current_request
+from .core import prevent, stop, State, States, current_request
 from .tag import Tag
 from .runner import AppRunner as App
 from .web import WebApp
@@ -22,6 +22,7 @@ __all__ = [
     "__version__",
     "Tag",  # the main thing
     "State",    # State management
+    "States",   # Multi-State management container
     "Router",   # SPA hash-based router
     "WebApp",   # the ASGI runner
 

--- a/htag/core.py
+++ b/htag/core.py
@@ -210,6 +210,43 @@ class State:
         return str(self.value)
 
 
+class States:
+    """A container for multiple State objects, allowing bulk save (dump) and load."""
+    def __init__(self, **kwargs):
+        object.__setattr__(self, "_states", {})
+        for key, value in kwargs.items():
+            self._states[key] = State(value)
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._states:
+            return self._states[name]
+        raise AttributeError(f"'States' object has no attribute '{name}'")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+        elif name in self._states:
+            if value is self._states[name]:
+                return
+            if isinstance(value, State):
+                value = value.value
+            self._states[name].value = value
+        else:
+            raise AttributeError(f"Cannot create attribute '{name}'. Declare it in States() initialization.")
+
+    def dump(self) -> dict:
+        """Returns a dictionary of all state values."""
+        return {k: v.get() for k, v in self._states.items()}
+
+    def load(self, data: dict) -> None:
+        """Loads values from a dictionary into the existing states."""
+        for key, value in data.items():
+            if key in self._states:
+                self._states[key].value = value
+            else:
+                self._states[key] = State(value)
+
+
 class _StateProxy:
     """A proxy that delegates everything to a value and notifies a parent State on mutations."""
 

--- a/tests/test_states_jules.py
+++ b/tests/test_states_jules.py
@@ -1,0 +1,44 @@
+import pytest
+from htag.core import States, State
+
+def test_states_init_jules():
+    s = States(a=1, b="hello")
+    assert isinstance(s.a, State)
+    assert s.a.get() == 1
+    assert isinstance(s.b, State)
+    assert s.b.get() == "hello"
+
+def test_states_getattr_jules():
+    s = States(val=42)
+    assert s.val == 42 # Uses State's __eq__
+    assert s.val.get() == 42
+
+    with pytest.raises(AttributeError):
+        _ = s.missing
+
+def test_states_setattr_jules():
+    s = States(val=10)
+    s.val = 20
+    assert s.val.get() == 20
+
+    # Check that in-place operators work through the proxy
+    s.val += 5
+    assert s.val.get() == 25
+
+    with pytest.raises(AttributeError, match="Cannot create attribute"):
+        s.new_val = 100
+
+def test_states_dump_jules():
+    s = States(x=1, y=2, z=[1, 2])
+    s.z.append(3)
+    data = s.dump()
+    assert data == {"x": 1, "y": 2, "z": [1, 2, 3]}
+
+def test_states_load_jules():
+    s = States(x=1, y=2)
+    s.load({"x": 10, "new_var": "created"})
+
+    assert s.x.get() == 10
+    assert s.y.get() == 2
+    assert s.new_var.get() == "created"
+    assert s.dump() == {"x": 10, "y": 2, "new_var": "created"}


### PR DESCRIPTION
This adds the `States` class to `htag.core` and exports it in `htag.__init__.py`, as discussed. It wraps multiple `State` objects and provides `.dump()` and `.load()` to fetch/hydrate all states at once.
Includes comprehensive tests and updates to the developer SKILL file.

---
*PR created automatically by Jules for task [13632112473747294325](https://jules.google.com/task/13632112473747294325) started by @manatlan*